### PR TITLE
Fix overlay restoration bug

### DIFF
--- a/DailyDashboard/main_dashboard.py
+++ b/DailyDashboard/main_dashboard.py
@@ -567,7 +567,7 @@ class DashboardWindow(QMainWindow):
             self.show()
             self.raise_()
             self.activateWindow()
-            self.overlay.true()
+            self.overlay.show()
             self._is_hidden_to_tray = False
 
 


### PR DESCRIPTION
## Summary
- restore overlay properly when restoring window from tray

## Testing
- `python -m py_compile main_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68405f2941248332a3dbe4282587e726