### PR TITLE
Fix overlay visibility on closeEvent

### DIFF
--- a/DailyDashboard/main_dashboard.py
+++ b/DailyDashboard/main_dashboard.py
@@ -552,7 +552,7 @@ class DashboardWindow(QMainWindow):
         """
         event.ignore()
         self.hide()
-        self.overlay.show()
+        self.overlay.hide()
         self._is_hidden_to_tray = True
         self.tray.showMessage(
             "Dashboard Minimized",


### PR DESCRIPTION
## Summary
- update closeEvent to hide overlay instead of showing it

## Testing
- `python -m py_compile DailyDashboard/main_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_6840630888688332a91886e244a76a9f