### PR TITLE
Fix overlay call in show_dashboard

### DIFF
--- a/DailyDashboard/main_dashboard.py
+++ b/DailyDashboard/main_dashboard.py
@@ -567,7 +567,7 @@ class DashboardWindow(QMainWindow):
             self.show()
             self.raise_()
             self.activateWindow()
-            self.overlay.true()
+            self.overlay.show()
             self._is_hidden_to_tray = False
 
 


### PR DESCRIPTION
## Summary
- fix typo in DashboardWindow.show_dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840630830308332bec28e06f590abdc