### PR TITLE
Fix tray overlay restore

### DIFF
--- a/DailyDashboard/main_dashboard.py
+++ b/DailyDashboard/main_dashboard.py
@@ -567,7 +567,10 @@ class DashboardWindow(QMainWindow):
             self.show()
             self.raise_()
             self.activateWindow()
-            self.overlay.true()
+            # `OverlayTimer` does not implement a `true()` method.
+            # The intent is to re-show the overlay when restoring the
+            # dashboard from the system tray.
+            self.overlay.show()
             self._is_hidden_to_tray = False
 
 


### PR DESCRIPTION
## Summary
- fix incorrect call to non-existent method in tray restore handler

## Testing
- `python -m py_compile DailyDashboard/main_dashboard.py DailyDashboard/pomodoro_widget.py`

------
https://chatgpt.com/codex/tasks/task_e_68405ea6b330833293c4a653a7a6d14c