### PR TITLE
Add PSIMSLeads request flow documentation

### DIFF
--- a/docs/request_flow.md
+++ b/docs/request_flow.md
@@ -1,0 +1,78 @@
+# Request Flow Overview
+
+This document describes how a query travels from the UI to the database in the `PSIMSLeads` application.
+
+## Flow Summary
+1. **User Interface** – `Form1` loads settings and calls `FoxTalkClient.ConnectAsync` to open the socket connection.
+2. **Query Construction** – `PSIMSLeadsQuery` builds XML requests such as `BuildCallPerson` or `BuildCallVehicle`.
+3. **Network Transfer** – `FoxTalkClient` writes the query frames over TCP to the remote LEADS server.
+4. **Response Handling** – incoming frames are parsed and processed by `FoxTalkClient` and `PSIMSLeadsQuery`.
+5. **Persistence** – application data can be saved using `PSIMSLeadsDB` to the `CT_PSIMS` database.
+
+## Relevant Code Snippets
+
+```csharp
+// Connect to the server and start listening
+await _foxTalkClient.ConnectAsync(settings.SendIPAddress, settings.SendPort);
+await _foxTalkClient.StartCoreListeningThread().ConfigureAwait(true);
+```
+*Form1.cs*【F:PSIMSLeads3/PSIMSLeads/Form1.cs†L30-L59】
+
+```csharp
+public async Task ConnectAsync(string serverAddress, int port)
+{
+    _logger.LogResponse($"Connecting to server {serverAddress}:{port}...");
+    await _tcpClient.ConnectAsync(serverAddress, port);
+    _networkStream = _tcpClient.GetStream();
+    // Start read/write loops...
+}
+```
+*FoxTalkClient.cs*【F:PSIMSLeads3/PSIMSLeads/FoxTalkClient.cs†L104-L135】
+
+```csharp
+_logger.LogResponse("Sending data message from {model.StateUsername} at workstation {model.WSID}");
+await GetCurrentClient().SendDataMessage(model);
+```
+*PSIMSLeadsQuery.cs* (inside `BuildCallPerson` and other builders)【F:PSIMSLeads3/PSIMSLeads/PSIMSLeadsQuery.cs†L86-L109】
+
+```csharp
+public async Task StoreAppData(int nFromService, string data)
+{
+    using (var db = new PSIMSContext(ConnectionString))
+    {
+        var entity = new PSIMSStateData() { EntryData = data };
+        db.PSIMSStateDatas.Add(entity);
+        await db.SaveChangesAsync();
+    }
+}
+```
+*PSIMSLeadsDB.cs*【F:PSIMSLeads3/PSIMSLeads/PSIMSLeadsDB.cs†L21-L48】
+
+Connection strings for the database are defined in *App.config*:
+
+```xml
+<add name="PSIMSContext" connectionString="Server=localhost;Database=CT_PSIMS;uid=CT_DBAdmin;password=22seavey;Trusted_Connection=True;" providerName="System.Data.SqlClient" />
+```
+*App.config*【F:PSIMSLeads3/PSIMSLeads/App.config†L16-L18】
+
+## Mermaid Diagram
+
+```mermaid
+sequenceDiagram
+    participant UI as Form1
+    participant Core as PSIMSCore
+    participant Query as PSIMSLeadsQuery
+    participant Client as FoxTalkClient
+    participant Remote as LEADS Server
+    participant DB as CT_PSIMS
+
+    UI->>Client: ConnectAsync()
+    UI->>Core: Send query
+    Core->>Query: Build XML
+    Query->>Client: SendDataMessage
+    Client->>Remote: TCP frames
+    Remote-->>Client: Response frames
+    Client->>Query: Process response
+    Query->>DB: StoreAppData()
+```
+


### PR DESCRIPTION
## Summary
- document client to database request flow for PSIMSLeads
- include mermaid diagram showing the flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406da4e99483328b0c2db17fed00f6